### PR TITLE
Recognize GeoJSON as JSON

### DIFF
--- a/socrata-http-client/src/main/scala/com/socrata/http/client/HttpClient.scala
+++ b/socrata-http-client/src/main/scala/com/socrata/http/client/HttpClient.scala
@@ -53,6 +53,8 @@ trait HttpClient extends Closeable {
 object HttpClient {
   val jsonContentTypeBase = "application/json"
   val jsonContentType = ContentType.create(jsonContentTypeBase, StandardCharsets.UTF_8)
+  val geoJsonContentTypeBase = "application/vnd.geo+json"
+  val geoJsonContentType = ContentType.create(geoJsonContentTypeBase, StandardCharsets.UTF_8)
   val formContentTypeBase = "application/x-www-form-urlencoded"
   val formContentType = ContentType.create(formContentTypeBase, StandardCharsets.UTF_8)
 }

--- a/socrata-http-client/src/main/scala/com/socrata/http/client/Response.scala
+++ b/socrata-http-client/src/main/scala/com/socrata/http/client/Response.scala
@@ -178,7 +178,8 @@ class StandardResponse(responseInfo: ResponseInfo, rawInputStream: InputStream) 
 
   lazy val isJson: Boolean =
     contentType match {
-      case Some(ct) => ct.getBaseType == HttpClient.jsonContentTypeBase
+      case Some(ct) => ct.getBaseType == HttpClient.jsonContentTypeBase ||
+                       ct.getBaseType == HttpClient.geoJsonContentTypeBase
       case None => false
     }
 


### PR DESCRIPTION
socrata-http-client doesn't recognize any content type except application/json as JSON, which prevents use of this library for reading GeoJSON responses. Adding code to recognize application/vnd.geo+json as a JSON content type.
