### PR TITLE
Include SocketTimeoutException in cause of ReceiveTimeout.

### DIFF
--- a/socrata-http-client/src/main/scala/com/socrata/http/client/HttpClientHttpClient.scala
+++ b/socrata-http-client/src/main/scala/com/socrata/http/client/HttpClientHttpClient.scala
@@ -168,8 +168,8 @@ class HttpClientHttpClient(executor: Executor, options: HttpClientHttpClient.Opt
           throw e.getCause
         case e: SocketException if e.getMessage == "Socket closed" =>
           probablyAborted(e)
-        case _: SocketTimeoutException =>
-          receiveTimeout()
+        case e: SocketTimeoutException =>
+          receiveTimeout(e)
         case e: InterruptedIOException =>
           probablyAborted(e)
         case e: IOException if e.getMessage == "Request already aborted" =>
@@ -201,7 +201,7 @@ class HttpClientHttpClient(executor: Executor, options: HttpClientHttpClient.Opt
               probablyAborted(e)
             case e: java.net.SocketTimeoutException =>
               exceptionWhileReading = true
-              receiveTimeout()
+              receiveTimeout(e)
             case e: Throwable =>
               exceptionWhileReading = true
               throw e

--- a/socrata-http-client/src/main/scala/com/socrata/http/client/exceptions/Exceptions.scala
+++ b/socrata-http-client/src/main/scala/com/socrata/http/client/exceptions/Exceptions.scala
@@ -1,13 +1,13 @@
 package com.socrata.http.client.exceptions
 
 import javax.activation.MimeType
-import java.net.ConnectException
+import java.net.{SocketTimeoutException, ConnectException}
 
 class HttpClientException(msg: String = null, cause: Throwable = null) extends Exception(msg, cause)
 
 class HttpClientTimeoutException extends HttpClientException
 class ConnectTimeout extends HttpClientTimeoutException
-class ReceiveTimeout extends HttpClientTimeoutException
+class ReceiveTimeout(cause: Throwable = null) extends HttpClientTimeoutException
 class FullTimeout extends HttpClientTimeoutException
 
 class LivenessCheckFailed extends HttpClientException

--- a/socrata-http-client/src/main/scala/com/socrata/http/client/exceptions/package.scala
+++ b/socrata-http-client/src/main/scala/com/socrata/http/client/exceptions/package.scala
@@ -4,7 +4,7 @@ import javax.activation.MimeType
 
 package object exceptions {
   def connectTimeout() = throw new ConnectTimeout
-  def receiveTimeout() = throw new ReceiveTimeout
+  def receiveTimeout(cause: Throwable = null) = throw new ReceiveTimeout(cause)
   def connectFailed(cause: java.net.ConnectException) = throw new ConnectFailed(cause)
   def livenessCheckFailed() = throw new LivenessCheckFailed
   def fullTimeout() = throw new FullTimeout


### PR DESCRIPTION
Yes, this is generally a slightly useless and silly thing to do,
but has a slight chance of figuring out why we are sometimes getting
unexpected receive timeouts in some places.
