### PR TITLE
Add logged request headers to MDC

### DIFF
--- a/socrata-http-server/src/main/scala/com/socrata/http/server/util/handlers/NewLoggingHandler.scala
+++ b/socrata-http-server/src/main/scala/com/socrata/http/server/util/handlers/NewLoggingHandler.scala
@@ -43,12 +43,11 @@ class NewLoggingHandler(underlying: HttpService, options: LoggingOptions) extend
         else ""
       log.info("<<< {}ms{}", (end - start)/1000000, extra)
 
-      MDC.clear()
-
       val headers = options.logResponseHeaders.flatMap { hdr =>
         trueResp.getHeaders(hdr).asScala.map { value => hdr + ": " + value }.toSeq
       }
       if (!headers.isEmpty) log.info("<<< RespHeaders:: " + headers.mkString(", "))
+      MDC.clear()
     }
   }
 }


### PR DESCRIPTION
...so that we can trace every log line of a request with the `X-Socrata-RequestId`, and any other headers we want, like the 4x4 / Resource.
