### PR TITLE
Make liveness check port lazy so that we can log some port mapping in…

### DIFF
--- a/socrata-http-server/src/main/scala/com/socrata/http/server/livenesscheck/LivenessCheckConfig.scala
+++ b/socrata-http-server/src/main/scala/com/socrata/http/server/livenesscheck/LivenessCheckConfig.scala
@@ -5,7 +5,7 @@ import com.typesafe.config.Config
 
 class LivenessCheckConfig(config: Config, root: String) extends ConfigClass(config, root) {
   /** Listen on port if specified, otherwise use ephemeral port. */
-  val port = optionally(getInt("port"))
+  lazy val port = optionally(getInt("port"))
   /** Bind to address of the specific hostname or IP if specified, otherwise use wildcard. This should be set on
     * systems with multiple interfaces on the same network or you may risk sending responses from the wrong IP.
     */


### PR DESCRIPTION
…fo when docker dynamic port mapping is used.