### PR TITLE
Only use rand bytes to match jobs in liveness chk

### DIFF
--- a/socrata-http-client/src/main/scala/com/socrata/http/client/LivenessChecker.scala
+++ b/socrata-http-client/src/main/scala/com/socrata/http/client/LivenessChecker.scala
@@ -24,7 +24,7 @@ final class LivenessCheckTarget private[client] (private [client] val host: Inet
 
   override def equals(o: Any) = o match {
     case that: LivenessCheckTarget =>
-      java.util.Arrays.equals(this.address, that.address) && this.port == that.port && java.util.Arrays.equals(this.response, that.response)
+      java.util.Arrays.equals(this.response, that.response)
     case _ => false
   }
 


### PR DESCRIPTION
* It seems that when two docker containers (A,B)
  live on the same host, and A makes a liveness
  check to B, the source ip on the packet back
  from B may not be what A expects for the job.

Refs EN-1737