### PR TITLE
Support pulling multiple values out of query parameters

### DIFF
--- a/project/SocrataHttpServer.scala
+++ b/project/SocrataHttpServer.scala
@@ -23,6 +23,54 @@ object SocrataHttpServer {
 
     // macro-paradise macros
     resolvers += Resolver.sonatypeRepo("snapshots"),
-    addCompilerPlugin("org.scalamacros" % "paradise" % "2.0.1" cross CrossVersion.full)
+    addCompilerPlugin("org.scalamacros" % "paradise" % "2.0.1" cross CrossVersion.full),
+    sourceGenerators in Compile <+= (sourceManaged in Compile).map(genParses)
   )
+
+  def genParse(n: Int): String = {
+    val typeVars = (0 until n).map { i => ('A' + i).toChar }.toIndexedSeq
+    val resultTypes = typeVars.map("Option[" + _ + "]")
+    val typeParams = typeVars.map(_ + " : Extractor")
+    val paramVars = (1 to n).map("r" + _).toIndexedSeq
+    val resultVars = (1 to n).map("res" + _).toIndexedSeq
+
+    val formals = paramVars.map { p => p + ": String" }
+
+    val sb = new StringBuilder
+    sb.append("def parseQueryParametersAs[").append(typeParams.mkString(", ")).append("](").append(formals.mkString(",")).append(") : Either[Seq[UnparsableParam], (").append(resultTypes.mkString(", ")).append(")] = {\n")
+
+    (resultVars, typeVars, paramVars).zipped.foreach { (out, typ, in) =>
+      sb.append("  val ").append(out).append(" = self.parseQueryParameterAs[").append(typ).append("](").append(in).append(")\n")
+    }
+    val condition = resultVars.map(_ + ".isInstanceOf[UnparsableParam]").mkString(" || ")
+    sb.append("  if(").append(condition).append(") {\n")
+    sb.append("    Left(Seq(").append(resultVars.mkString(", ")).append(").collect { case x: UnparsableParam => x })\n")
+    sb.append("  } else {\n")
+    sb.append("    Right((").append(resultVars.map(_ + ".get").mkString(", ")).append("))\n")
+    sb.append("  }\n")
+    sb.append("}\n")
+
+    sb.toString
+  }
+
+  def genParses(base: File): Seq[File] = {
+    val targetDir = base / "com" / "socrata" / "http" / "server"
+    targetDir.mkdirs()
+    val outfile = targetDir / "GeneratedHttpRequestApi.scala"
+    val f = new java.io.FileWriter(outfile)
+    try {
+      f.write("""package com.socrata.http.server
+
+import com.socrata.http.server.routing.Extractor
+
+final class GeneratedHttpRequestApi(val `private once 2.10 is no longer a thing` : HttpRequest) extends AnyVal {
+  private def self = `private once 2.10 is no longer a thing`
+""")
+      for(i <- 1 to 22) f.write(genParse(i))
+      f.write("}\n")
+    } finally {
+      f.close()
+    }
+    Seq(outfile)
+  }
 }

--- a/project/SocrataHttpServer.scala
+++ b/project/SocrataHttpServer.scala
@@ -37,6 +37,30 @@ object SocrataHttpServer {
     val formals = paramVars.map { p => p + ": String" }
 
     val sb = new StringBuilder
+    sb.append(s"""/**
+ * Parse $n optional query parameters, returning either `Right` containing
+ * a tuple of the parsed values, or `Left` containing a collection of errors
+ * for all the unparsable parameters.  If `Left` is returned, the collection
+ * will be non-empty.
+ *
+""")
+    sb.append(" * @example {{{\n")
+    val exampleTypeUniverse = Seq("String", "Int")
+    val exampleTypes = (1 to n).map { i => exampleTypeUniverse(i % exampleTypeUniverse.length) }
+    val exampleParameters = (1 to n).map("param" + _)
+    val exampleResults = (1 to n).map("result" + _)
+    val exampleParameterStrings = exampleParameters.map("\"" + _ + "\"")
+    sb.append(" * req.parseQueryParametersAs[").append(exampleTypes.mkString(", ")).append("](").append(exampleParameterStrings.mkString(", ")).append(") match {\n")
+    sb.append(" *   case Right((").append(exampleResults.mkString(", ")).append(")) =>\n")
+    (exampleParameters, exampleResults).zipped.foreach { (param, result) =>
+      val string = "\"" + param + " = \""
+      sb.append(" *     println(").append(string).append(" + ").append(result).append(")\n")
+    }
+    sb.append(" *   case Left(errors) =>\n")
+    sb.append(" *     println(\"oops: \" + errors)\n")
+    sb.append(" * }\n")
+    sb.append(" * }}}\n")
+    sb.append(" */\n")
     sb.append("def parseQueryParametersAs[").append(typeParams.mkString(", ")).append("](").append(formals.mkString(",")).append(") : Either[Seq[UnparsableParam], (").append(resultTypes.mkString(", ")).append(")] = {\n")
 
     (resultVars, typeVars, paramVars).zipped.foreach { (out, typ, in) =>

--- a/socrata-http-server/src/main/scala/com/socrata/http/server/HttpRequest.scala
+++ b/socrata-http-server/src/main/scala/com/socrata/http/server/HttpRequest.scala
@@ -109,8 +109,20 @@ object HttpRequest {
     def queryParameter(parameterName: String): Option[String] =
       servletRequest.queryParameters.get(parameterName)
 
+    @deprecated(message = "Use \"parseQueryParameterAs[T]\" instead", since = "3.8.0")
     def queryParameterAs[T](parameterName: String)(implicit extractor: Extractor[T]): Option[T] =
-      queryParameter(parameterName).flatMap(extractor.extract(_))
+      parseQueryParameterAs[T](parameterName).toOption.flatten
+
+    /** @return The first value associated with the given parameter in the query string. */
+    def parseQueryParameterAs[T](parameterName: String)(implicit extractor: Extractor[T]): ParamParseResult[Option[T]] =
+      queryParameter(parameterName) match {
+        case Some(p) =>
+          extractor.extract(p) match {
+            case Some(r) => ParsedParam(Some(r))
+            case None => UnparsableParam(parameterName, p)
+          }
+        case None => ParsedParam(None)
+      }
 
     def method: String = servletRequest.getMethod
 

--- a/socrata-http-server/src/main/scala/com/socrata/http/server/HttpRequest.scala
+++ b/socrata-http-server/src/main/scala/com/socrata/http/server/HttpRequest.scala
@@ -74,6 +74,9 @@ object HttpRequest {
     }
   }
 
+  implicit def generatedHttpRequestApi(req: HttpRequest): GeneratedHttpRequestApi =
+    new GeneratedHttpRequestApi(req)
+
   // This will allow us to add more (stateless) methods to HttpRequest without breaking binary compatibility
   final implicit class HttpRequestApi(val `private once 2.10 is no longer a thing`: HttpRequest) extends AnyVal {
     private def self = `private once 2.10 is no longer a thing`

--- a/socrata-http-server/src/main/scala/com/socrata/http/server/ParamParseResult.scala
+++ b/socrata-http-server/src/main/scala/com/socrata/http/server/ParamParseResult.scala
@@ -1,0 +1,25 @@
+package com.socrata.http.server
+
+sealed trait ParamParseResult[+A] {
+  def toOption: Option[A]
+  def isValid: Boolean
+  def get: A
+  def getOrElse[B >: A](default: => B): B
+  def map[B](f: A => B): ParamParseResult[B]
+}
+
+case class ParsedParam[+A](value: A) extends ParamParseResult[A] {
+  override val toOption = Some(value)
+  override val isValid = true
+  override val get = value
+  override def getOrElse[B >: A](default: => B) = value
+  override def map[B](f: A => B) = ParsedParam(f(value))
+}
+
+case class UnparsableParam(name: String, rawValue: String) extends ParamParseResult[Nothing] {
+  override val toOption = None
+  override val isValid = false
+  override def get = throw new java.util.NoSuchElementException("Attempted to read unparsable param.")
+  override def getOrElse[B](default: => B) = default
+  override def map[B](f: Nothing => B) = this
+}

--- a/socrata-http-server/src/main/scala/com/socrata/http/server/routing/Extractor.scala
+++ b/socrata-http-server/src/main/scala/com/socrata/http/server/routing/Extractor.scala
@@ -66,4 +66,18 @@ object Extractor {
       try { Some(BigInt(s)) }
       catch { case _: NumberFormatException => None }
   }
+
+  /** @note This DISALLOWS NaN and Infinity! */
+  implicit object FloatExtractor extends Extractor[Float] {
+    def extract(s: String): Option[Float] =
+      try { Some(java.lang.Float.parseFloat(s)).filterNot { f => f.isNaN || f.isInfinite } }
+      catch { case _: NumberFormatException => None }
+  }
+
+  /** @note This DISALLOWS NaN and Infinity! */
+  implicit object DoubleExtractor extends Extractor[Double] {
+    def extract(s: String): Option[Double] =
+      try { Some(java.lang.Double.parseDouble(s)).filterNot { f => f.isNaN || f.isInfinite } }
+      catch { case _: NumberFormatException => None }
+  }
 }

--- a/socrata-http-server/src/main/scala/com/socrata/http/server/routing/Extractor.scala
+++ b/socrata-http-server/src/main/scala/com/socrata/http/server/routing/Extractor.scala
@@ -45,4 +45,13 @@ object Extractor {
       else None
     }
   }
+
+  implicit object BooleanExtractor extends Extractor[Boolean] {
+    def extract(s: String): Option[Boolean] =
+      s.toLowerCase match {
+        case "true" => Some(true)
+        case "false" => Some(false)
+        case _ => None
+      }
+  }
 }

--- a/socrata-http-server/src/main/scala/com/socrata/http/server/routing/Extractor.scala
+++ b/socrata-http-server/src/main/scala/com/socrata/http/server/routing/Extractor.scala
@@ -54,4 +54,16 @@ object Extractor {
         case _ => None
       }
   }
+
+  implicit object BigDecimalExtractor extends Extractor[BigDecimal] {
+    def extract(s: String): Option[BigDecimal] =
+      try { Some(BigDecimal(s)) }
+      catch { case _: NumberFormatException => None }
+  }
+
+  implicit object BigIntExtractor extends Extractor[BigInt] {
+    def extract(s: String): Option[BigInt] =
+      try { Some(BigInt(s)) }
+      catch { case _: NumberFormatException => None }
+  }
 }


### PR DESCRIPTION
Add `parseQueryParametersAs` to extract multiple query params

This allows pulling out the parameters using conversions based on defined extractors (some of which can live in Socrata-Http, but also some which can live inside of the individual project for custom types).