### PR TITLE
Fix liveness checking in the presence of multiple checks for one target

### DIFF
--- a/socrata-http-client/src/main/scala/com/socrata/http/client/LivenessChecker.scala
+++ b/socrata-http-client/src/main/scala/com/socrata/http/client/LivenessChecker.scala
@@ -354,7 +354,7 @@ private[client] final class LivenessCheckerImpl(intervalMS: Long, rangeMS: Int, 
     job.missed += 1
     if(job.missed > missable) {
       log.trace("More than {} packets missed in a row by {}", missable, job)
-      pings.remove(job.target)
+      pings.remove(LivenessCheckResponse(job.target.response))
       pingQueue.remove(job)
       for(f <- job.onFailures.keys.asScala) {
         if(!f.cancelled) executor.execute(f)
@@ -390,7 +390,7 @@ private[client] final class LivenessCheckerImpl(intervalMS: Long, rangeMS: Int, 
 
   private def startJob(job: PendingJob) {
     log.trace("Starting a job for {}", job.target)
-    val existingJob = pings.get(job.target)
+    val existingJob = pings.get(LivenessCheckResponse(job.target.response))
     if(existingJob == null) {
       log.trace("New job!")
       val newJob = new Job(job.target)


### PR DESCRIPTION
This was ultimately caused by java.util.Map's `get` and `remove` methods
taking `Object` instead of `K`.  The reason we're using `ju.Map` here
instead of a Scala `Map` is because in other places in this code we're
using a Java `ConcurrentHashMap` and I thought it was important to have
just one map API in play.  Sigh.  Anyway I've now checked all uses of
`pings` to make sure the right keys are being used.