### PR TITLE
Work around Jetty behavior change re: auto-consuming the body on response

### DIFF
--- a/socrata-http-jetty/src/main/scala/com/socrata/http/server/AbstractSocrataServerJetty.scala
+++ b/socrata-http-jetty/src/main/scala/com/socrata/http/server/AbstractSocrataServerJetty.scala
@@ -68,7 +68,9 @@ abstract class AbstractSocrataServerJetty(handler: Handler, options: AbstractSoc
           using(new ResourceScope("error handler")) { rs =>
             val req = new ConcreteHttpRequest(new AugmentedHttpServletRequest(request), rs)
             baseRequest.setHandled(true)
-            errorHandler(req)(response)
+            val resp = new ConsumingHttpServletResponse(request, response)
+            try { errorHandler(req)(resp) }
+            finally { resp.consume() }
           }
         }
       })

--- a/socrata-http-jetty/src/main/scala/com/socrata/http/server/ConsumingHttpServletResponse.scala
+++ b/socrata-http-jetty/src/main/scala/com/socrata/http/server/ConsumingHttpServletResponse.scala
@@ -1,0 +1,59 @@
+package com.socrata.http.server
+
+import java.io.{InputStream, Reader, IOException}
+import javax.servlet.http.{HttpServletResponse, HttpServletRequest, HttpServletResponseWrapper}
+
+private class ConsumingHttpServletResponse(request: HttpServletRequest, val underlying: HttpServletResponse) extends HttpServletResponseWrapper(underlying) {
+  def consume() {
+    trait Consumer { def consume() }
+
+    class InputStreamConsumer(stream: InputStream) extends Consumer {
+      def consume() {
+        val buf = new Array[Byte](4096)
+        while(stream.read(buf) != -1) {}
+      }
+    }
+
+    class ReaderConsumer(reader: Reader) extends Consumer {
+      def consume() {
+        val buf = new Array[Char](4096)
+        while(reader.read(buf) != -1) {}
+      }
+    }
+
+    try {
+      val consumer =
+        try {
+          Some(new InputStreamConsumer(request.getInputStream))
+        } catch {
+          case _ : IllegalStateException =>
+            try {
+              Some(new ReaderConsumer(request.getReader))
+            } catch {
+              case _ : IllegalStateException =>
+                None // uh... that shouldn't happen.  Guess we'll just not consume it then.
+            }
+        }
+
+      consumer.foreach(_.consume())
+    } catch {
+      case _ : IOException =>
+        // we'll just ignore this, because we're on our way out already
+    }
+  }
+
+  override def getOutputStream = {
+    consume()
+    underlying.getOutputStream
+  }
+
+  override def getWriter = {
+    consume()
+    underlying.getWriter
+  }
+
+  override def sendError(code: Int) = {
+    consume()
+    underlying.sendError(code)
+  }
+}

--- a/socrata-http-jetty/src/main/scala/com/socrata/http/server/Handlers.scala
+++ b/socrata-http-jetty/src/main/scala/com/socrata/http/server/Handlers.scala
@@ -8,22 +8,28 @@ import com.rojoma.simplearm.v2._
 import org.slf4j.MDC
 
 private class FunctionHandler(handler: HttpService) extends AbstractHandler {
-  def handle(target: String, baseRequest: Request, request: HttpServletRequest, response: HttpServletResponse): Unit = {
+  def handle(target: String, baseRequest: Request, request: HttpServletRequest, baseResponse: HttpServletResponse): Unit = {
     if(isStarted) {
       baseRequest.setHandled(true)
       try {
         MDC.clear()
         using(new ResourceScope("request scope")) { rs =>
           val request = new ConcreteHttpRequest(new HttpRequest.AugmentedHttpServletRequest(baseRequest), rs)
-          try { // force checking the path and query parameters
-            request.queryParametersSeq
-            request.requestPath
-          } catch {
-            case _: IllegalArgumentException =>
-              response.sendError(HttpServletResponse.SC_BAD_REQUEST)
-              return
+          val response = new ConsumingHttpServletResponse(baseRequest, baseResponse)
+
+          try {
+            try { // force checking the path and query parameters
+              request.queryParametersSeq
+              request.requestPath
+            } catch {
+              case _: IllegalArgumentException =>
+                response.sendError(HttpServletResponse.SC_BAD_REQUEST)
+                return
+            }
+            handler(request)(response)
+          } finally {
+            response.consume()
           }
-          handler(request)(response)
         }
       } finally {
         MDC.clear()


### PR DESCRIPTION
Now when the outputstream is requested, or if it falls off the end, we'll
explicitly consume any input before that happens.