### PR TITLE
Use ContentType.parse instead of .create in processBlob

### DIFF
--- a/socrata-http-client/src/main/scala/com/socrata/http/client/HttpClientHttpClient.scala
+++ b/socrata-http-client/src/main/scala/com/socrata/http/client/HttpClientHttpClient.scala
@@ -296,7 +296,7 @@ class HttpClientHttpClient(executor: Executor, options: HttpClientHttpClient.Opt
 
   def processBlob(req: BlobHttpRequest): RawResponse with Closeable = {
     init()
-    val sendEntity = new InputStreamEntity(req.contents, -1, ContentType.create(req.contentType))
+    val sendEntity = new InputStreamEntity(req.contents, -1, ContentType.parse(req.contentType))
     val op = bodyEnclosingOp(req)
     op.setEntity(sendEntity)
     send(op, req.builder.timeoutMS, pingTarget(req))


### PR DESCRIPTION
We're already doing that elsewhere in this codepath, and at some point
.create became more strict (wanting only the base type without parameters)