### PR TITLE
EN-66069: Java 9+ Compatibility

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.12.8"
+ThisBuild / scalaVersion := "2.12.19"
 
 ThisBuild / crossScalaVersions := Seq("2.10.4", "2.11.7", scalaVersion.value)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,9 +15,10 @@ object Dependencies {
 
   val jackson = "org.codehaus.jackson" % "jackson-mapper-asl" % "1.9.13"
 
-  val javaxServlet = "javax.servlet" % "javax.servlet-api" % "3.1.0"
+  val jakartaActivation = "jakarta.activation" % "jakarta.activation-api" % "2.1.3"
+  val jakartaServlet = "org.eclipse.jetty.toolchain" % "jetty-jakarta-servlet-api" % "5.0.2"
 
-  val jettyVersion = "9.4.24.v20191120"
+  val jettyVersion = "11.0.20"
   val jettyJmx = "org.eclipse.jetty" % "jetty-jmx" % jettyVersion
   val jettyServer = "org.eclipse.jetty" % "jetty-server" % jettyVersion
   val jettyServlet = "org.eclipse.jetty" % "jetty-servlet" % jettyVersion

--- a/socrata-http-client/build.sbt
+++ b/socrata-http-client/build.sbt
@@ -3,6 +3,7 @@ import Dependencies._
 name := "socrata-http-client"
 
 libraryDependencies ++= Seq(
+  jakartaServlet,
   apacheHttpClient exclude ("commons-logging", "commons-logging"),
   commonsIo,
   apacheHttpMime,

--- a/socrata-http-client/src/main/scala/com/socrata/http/client/LivenessChecker.scala
+++ b/socrata-http-client/src/main/scala/com/socrata/http/client/LivenessChecker.scala
@@ -145,8 +145,8 @@ private[client] final class LivenessCheckerImpl(intervalMS: Long, rangeMS: Int, 
   private val RandBytesSize = 16
   private val txPacketCapacity = 8 + RandBytesSize
   private val rxPacketHeader = txPacketCapacity
-  val txPacket = ByteBuffer.allocate(txPacketCapacity)
-  val rxPacket = ByteBuffer.allocate(512)
+  private val txPacket = ByteBuffer.allocate(txPacketCapacity)
+  private val rxPacket = ByteBuffer.allocate(512)
 
   private class Job(val target: LivenessCheckTarget) extends IntrusivePriorityQueueNode {
     def waitUntil = priority
@@ -329,7 +329,7 @@ private[client] final class LivenessCheckerImpl(intervalMS: Long, rangeMS: Int, 
     }
 
     rxPacket.flip()
-    log.debug("Received a {}-byte datagram from {}", rxPacket.limit, from)
+    log.debug("Received a {}-byte datagram from {}", rxPacket.limit(), from)
     processRxPacket(from)
     processPackets()
   }

--- a/socrata-http-client/src/main/scala/com/socrata/http/client/Response.scala
+++ b/socrata-http-client/src/main/scala/com/socrata/http/client/Response.scala
@@ -1,7 +1,7 @@
 package com.socrata.http.client
 
 import java.io.{InputStreamReader, Reader, InputStream}
-import javax.activation.{MimeTypeParseException, MimeType}
+import jakarta.activation.{MimeTypeParseException, MimeType}
 import java.nio.charset.{StandardCharsets, Charset}
 
 import com.rojoma.json.v3.io.{JsonReader, FusedBlockJsonEventIterator, JsonEvent}

--- a/socrata-http-client/src/main/scala/com/socrata/http/client/exceptions/Exceptions.scala
+++ b/socrata-http-client/src/main/scala/com/socrata/http/client/exceptions/Exceptions.scala
@@ -1,6 +1,6 @@
 package com.socrata.http.client.exceptions
 
-import javax.activation.MimeType
+import jakarta.activation.MimeType
 import java.net.{SocketTimeoutException, ConnectException}
 
 class HttpClientException(msg: String = null, cause: Throwable = null) extends Exception(msg, cause)

--- a/socrata-http-client/src/main/scala/com/socrata/http/client/exceptions/package.scala
+++ b/socrata-http-client/src/main/scala/com/socrata/http/client/exceptions/package.scala
@@ -1,6 +1,6 @@
 package com.socrata.http.client
 
-import javax.activation.MimeType
+import jakarta.activation.MimeType
 
 package object exceptions {
   def connectTimeout() = throw new ConnectTimeout

--- a/socrata-http-common/build.sbt
+++ b/socrata-http-common/build.sbt
@@ -3,6 +3,7 @@ import Dependencies._
 name := "socrata-http-common"
 
 libraryDependencies ++= Seq(
+  jakartaActivation,
   commonsCodec,
   commonsLang,
   jodaConvert,

--- a/socrata-http-common/src/main/scala/com/socrata/http/common/util/CharsetFor.scala
+++ b/socrata-http-common/src/main/scala/com/socrata/http/common/util/CharsetFor.scala
@@ -2,7 +2,7 @@ package com.socrata.http.common.util
 
 import java.awt.datatransfer.MimeTypeParseException
 import java.nio.charset.{IllegalCharsetNameException, StandardCharsets, Charset}
-import javax.activation.MimeType
+import jakarta.activation.MimeType
 import scala.runtime.ScalaRunTime
 
 import StandardCharsets._

--- a/socrata-http-common/src/main/scala/com/socrata/http/common/util/ContentNegotiation.scala
+++ b/socrata-http-common/src/main/scala/com/socrata/http/common/util/ContentNegotiation.scala
@@ -1,6 +1,6 @@
 package com.socrata.http.common.util
 
-import javax.activation.MimeType
+import jakarta.activation.MimeType
 import java.nio.charset.{StandardCharsets, UnsupportedCharsetException, IllegalCharsetNameException, Charset}
 import com.socrata.http.common.util.HttpUtils.{LanguageRange, CharsetRange, MediaRange}
 import java.awt.datatransfer.MimeTypeParseException

--- a/socrata-http-jetty/build.sbt
+++ b/socrata-http-jetty/build.sbt
@@ -3,6 +3,7 @@ import Dependencies._
 name := "socrata-http-jetty"
 
 libraryDependencies ++= Seq(
+  jakartaServlet % Provided,
   socrataUtils,
   jettyJmx,
   jettyServer,

--- a/socrata-http-jetty/src/main/scala/com/socrata/http/server/ConsumingHttpServletResponse.scala
+++ b/socrata-http-jetty/src/main/scala/com/socrata/http/server/ConsumingHttpServletResponse.scala
@@ -1,7 +1,7 @@
 package com.socrata.http.server
 
 import java.io.{InputStream, Reader, IOException}
-import javax.servlet.http.{HttpServletResponse, HttpServletRequest, HttpServletResponseWrapper}
+import jakarta.servlet.http.{HttpServletResponse, HttpServletRequest, HttpServletResponseWrapper}
 
 private class ConsumingHttpServletResponse(request: HttpServletRequest, val underlying: HttpServletResponse) extends HttpServletResponseWrapper(underlying) {
   def consume() {

--- a/socrata-http-jetty/src/main/scala/com/socrata/http/server/GzipParameters.scala
+++ b/socrata-http-jetty/src/main/scala/com/socrata/http/server/GzipParameters.scala
@@ -9,8 +9,7 @@ case class GzipParameters(excludeUserAgent: String => Boolean = Set.empty,
   def toOptions = SocrataServerJetty.Gzip.defaultOptions.
     withBufferSize(bufferSize).
     withMinGzipSize(minGzipSize).
-    withExcludedMimeTypes(toSet("excludeMimeTypes", excludeMimeTypes)).
-    withExcludedUserAgents(toSet("excludeUserAgent", excludeUserAgent))
+    withExcludedMimeTypes(toSet("excludeMimeTypes", excludeMimeTypes))
 
   private def toSet(name: String, f: String => Boolean): Set[String] = {
     if(f.isInstanceOf[Set[_]]) f.asInstanceOf[Set[String]]

--- a/socrata-http-jetty/src/main/scala/com/socrata/http/server/Handlers.scala
+++ b/socrata-http-jetty/src/main/scala/com/socrata/http/server/Handlers.scala
@@ -3,7 +3,7 @@ package com.socrata.http.server
 import scala.util.control.ControlThrowable
 import org.eclipse.jetty.server.handler.{HandlerWrapper, AbstractHandler}
 import org.eclipse.jetty.server.{Handler, Request}
-import javax.servlet.http.{HttpServletResponse, HttpServletRequest}
+import jakarta.servlet.http.{HttpServletResponse, HttpServletRequest}
 import java.util.concurrent.atomic.AtomicInteger
 import com.rojoma.simplearm.v2._
 import org.slf4j.{MDC, LoggerFactory}

--- a/socrata-http-jetty/src/main/scala/com/socrata/http/server/SocrataServerJettyServlet.scala
+++ b/socrata-http-jetty/src/main/scala/com/socrata/http/server/SocrataServerJettyServlet.scala
@@ -1,7 +1,7 @@
 package com.socrata.http.server
 
 import scala.collection.JavaConverters._
-import javax.servlet.DispatcherType
+import jakarta.servlet.DispatcherType
 import java.util.{EventListener, EnumSet}
 import org.eclipse.jetty.server.Handler
 import org.eclipse.jetty.servlet.ServletContextHandler
@@ -13,8 +13,8 @@ class SocrataServerJettyServlet(options: SocrataServerJettyServlet.Options) exte
 
 object SocrataServerJettyServlet {
   import scala.language.existentials
-  case class ServletSpec(servlet: Class[_ <: javax.servlet.Servlet], pathSpec: String)
-  case class FilterSpec(filter: Class[_ <: javax.servlet.Filter], pathSpec: String, dispatches: Set[DispatcherType])
+  case class ServletSpec(servlet: Class[_ <: jakarta.servlet.Servlet], pathSpec: String)
+  case class FilterSpec(filter: Class[_ <: jakarta.servlet.Filter], pathSpec: String, dispatches: Set[DispatcherType])
 
   abstract class Options extends AbstractSocrataServerJetty.Options {
     type OptT <: Options

--- a/socrata-http-server-ext/build.sbt
+++ b/socrata-http-server-ext/build.sbt
@@ -1,7 +1,9 @@
+import Dependencies.jakartaServlet
+
 name := "socrata-http-server-ext"
 
 libraryDependencies ++= Seq(
-  "javax.servlet" % "javax.servlet-api" % "3.1.0" % "provided"
+  jakartaServlet % Provided
 )
 
 Compile / sourceGenerators += Def.task { serverext.IntoResponseBuilder((Compile / sourceManaged).value) }

--- a/socrata-http-server-ext/src/main/scala/com/socrata/http/server/ext/HeaderMap.scala
+++ b/socrata-http-server-ext/src/main/scala/com/socrata/http/server/ext/HeaderMap.scala
@@ -1,6 +1,6 @@
 package com.socrata.http.server.ext
 
-import javax.servlet.http.HttpServletResponse
+import jakarta.servlet.http.HttpServletResponse
 
 import com.socrata.http.server.HttpResponse
 

--- a/socrata-http-server/build.sbt
+++ b/socrata-http-server/build.sbt
@@ -5,7 +5,7 @@ name := "socrata-http-server"
 libraryDependencies ++=
   Seq(
     commonsIo,
-    javaxServlet % "provided",
+    jakartaServlet,
     jodaConvert,
     jodaTime,
     scalaReflect(scalaVersion.value),
@@ -20,9 +20,9 @@ libraryDependencies ++=
         else Seq("org.scala-lang.modules" %% "scala-parser-combinators" % "2.1.0"))
 
 // macro-paradise macros
-addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
+addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full)
 
-Compile / sourceGenerators += Def.task { genParses((Compile / sourceManaged).value, (Compile / scalaVersion).value) }
+Compile / sourceGenerators += Def.task { genParses((Compile / sourceManaged).value, (Compile / scalaVersion).value) }.taskValue
 
 def genParse(n: Int, scalaVersion: String): String = {
   val typeVars = (0 until n).map { i => ('A' + i).toChar }

--- a/socrata-http-server/src/main/scala/com/socrata/http/server/-impl/ChainedHttpResponse.scala
+++ b/socrata-http-server/src/main/scala/com/socrata/http/server/-impl/ChainedHttpResponse.scala
@@ -1,6 +1,6 @@
 package com.socrata.http.server.`-impl`
 
-import javax.servlet.http.HttpServletResponse
+import jakarta.servlet.http.HttpServletResponse
 
 import com.socrata.http.server.HttpResponse
 

--- a/socrata-http-server/src/main/scala/com/socrata/http/server/HttpRequest.scala
+++ b/socrata-http-server/src/main/scala/com/socrata/http/server/HttpRequest.scala
@@ -10,7 +10,7 @@ import com.socrata.http.common.util.CharsetFor.UnparsableContentType
 
 import scala.collection.JavaConverters._
 import java.net.URLDecoder
-import javax.servlet.http.{HttpServletRequestWrapper, HttpServletRequest}
+import jakarta.servlet.http.{HttpServletRequestWrapper, HttpServletRequest}
 
 import com.socrata.http.common.util.{ContentNegotiation, HttpUtils, CharsetFor}
 import com.socrata.http.server.util.PreconditionParser

--- a/socrata-http-server/src/main/scala/com/socrata/http/server/implicits.scala
+++ b/socrata-http-server/src/main/scala/com/socrata/http/server/implicits.scala
@@ -4,10 +4,10 @@ import scala.language.implicitConversions
 
 import java.io.InputStreamReader
 import java.nio.charset.Charset
-import javax.activation.MimeType
+import jakarta.activation.MimeType
 
 import scala.collection.JavaConverters._
-import javax.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletRequest
 import java.net.URLDecoder
 
 import com.socrata.http.server.`-impl`.ChainedHttpResponse

--- a/socrata-http-server/src/main/scala/com/socrata/http/server/package.scala
+++ b/socrata-http-server/src/main/scala/com/socrata/http/server/package.scala
@@ -1,6 +1,6 @@
 package com.socrata.http
 
-import javax.servlet.http.HttpServletResponse
+import jakarta.servlet.http.HttpServletResponse
 
 import com.socrata.http.server.HttpRequest
 

--- a/socrata-http-server/src/main/scala/com/socrata/http/server/responses.scala
+++ b/socrata-http-server/src/main/scala/com/socrata/http/server/responses.scala
@@ -1,8 +1,8 @@
 package com.socrata.http.server
 
 import java.nio.charset.{StandardCharsets, Charset}
-import javax.activation.MimeType
-import javax.servlet.http.HttpServletResponse
+import jakarta.activation.MimeType
+import jakarta.servlet.http.HttpServletResponse
 import java.io.{InputStream, OutputStreamWriter, OutputStream, Writer}
 import java.net.URL
 

--- a/socrata-http-server/src/main/scala/com/socrata/http/server/util/ETagRequestHandler.scala
+++ b/socrata-http-server/src/main/scala/com/socrata/http/server/util/ETagRequestHandler.scala
@@ -2,8 +2,8 @@ package com.socrata.http.server.util
 
 import java.lang.String
 import java.text.SimpleDateFormat
-import javax.servlet.http.HttpServletRequest
-import javax.servlet.http.HttpServletResponse
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
 import java.text.ParseException
 import java.util.Date
 

--- a/socrata-http-server/src/main/scala/com/socrata/http/server/util/ErrorAdapter.scala
+++ b/socrata-http-server/src/main/scala/com/socrata/http/server/util/ErrorAdapter.scala
@@ -1,6 +1,6 @@
 package com.socrata.http.server.util
 
-import javax.servlet.http.HttpServletResponse
+import jakarta.servlet.http.HttpServletResponse
 import com.socrata.http.server.{HttpRequest, HttpService, HttpResponse}
 
 /** An adapter to catch unexpected errors.  This goes right below the

--- a/socrata-http-server/src/main/scala/com/socrata/http/server/util/RequestId.scala
+++ b/socrata-http-server/src/main/scala/com/socrata/http/server/util/RequestId.scala
@@ -1,6 +1,6 @@
 package com.socrata.http.server.util
 
-import javax.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletRequest
 import org.slf4j.MDC
 
 /**

--- a/socrata-http-server/src/main/scala/com/socrata/http/server/util/filters/InputByteCountingFilter.scala
+++ b/socrata-http-server/src/main/scala/com/socrata/http/server/util/filters/InputByteCountingFilter.scala
@@ -1,10 +1,10 @@
 package com.socrata.http.server.util.filters
 
-import javax.servlet.http.{HttpServletRequestWrapper, HttpServletRequest}
+import jakarta.servlet.http.{HttpServletRequestWrapper, HttpServletRequest}
 import InputByteCountingFilter._
 import com.socrata.http.server.HttpRequest.AugmentedHttpServletRequest
 import io.Codec
-import javax.servlet.ServletInputStream
+import jakarta.servlet.ServletInputStream
 import java.io._
 
 import com.socrata.http.server._
@@ -76,7 +76,7 @@ object InputByteCountingFilter {
 
       def isFinished: Boolean = underlying.isFinished
       def isReady(): Boolean = underlying.isReady
-      def setReadListener(x: javax.servlet.ReadListener) = underlying.setReadListener(x)
+      def setReadListener(x: jakarta.servlet.ReadListener) = underlying.setReadListener(x)
     }
 
     def bytesRead = count

--- a/socrata-http-server/src/main/scala/com/socrata/http/server/util/filters/OutputByteCountingFilter.scala
+++ b/socrata-http-server/src/main/scala/com/socrata/http/server/util/filters/OutputByteCountingFilter.scala
@@ -1,9 +1,9 @@
 package com.socrata.http.server.util.filters
 
 import OutputByteCountingFilter._
-import javax.servlet.ServletOutputStream
+import jakarta.servlet.ServletOutputStream
 import java.io._
-import javax.servlet.http.{HttpServletResponse, HttpServletResponseWrapper}
+import jakarta.servlet.http.{HttpServletResponse, HttpServletResponseWrapper}
 import com.socrata.http.server._
 
 trait OutputByteCountingFilter extends SimpleFilter[HttpRequest, HttpResponse] {
@@ -75,7 +75,7 @@ object OutputByteCountingFilter {
       }
 
       def isReady(): Boolean = underlying.isReady
-      def setWriteListener(x: javax.servlet.WriteListener): Unit = underlying.setWriteListener(x)
+      def setWriteListener(x: jakarta.servlet.WriteListener): Unit = underlying.setWriteListener(x)
 
       def bytesWritten = count
     }

--- a/socrata-http-server/src/main/scala/com/socrata/http/server/util/filters/ThreadRenamingFilter.scala
+++ b/socrata-http-server/src/main/scala/com/socrata/http/server/util/filters/ThreadRenamingFilter.scala
@@ -1,7 +1,7 @@
 package com.socrata.http.server.util.filters
 
 import com.socrata.http.server.{Filter, HttpResponse}
-import javax.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletRequest
 
 abstract class ThreadRenamingFilter[InDown, OutUp] extends Filter[InDown, OutUp, InDown, OutUp] {
   def apply(request: InDown, service: (InDown) => OutUp): OutUp = {

--- a/socrata-http-server/src/main/scala/com/socrata/http/server/util/handlers/LoggingHandler.scala
+++ b/socrata-http-server/src/main/scala/com/socrata/http/server/util/handlers/LoggingHandler.scala
@@ -1,7 +1,7 @@
 package com.socrata.http.server.util.handlers
 
 import com.socrata.http.server.{HttpRequest, HttpService}
-import javax.servlet.http.{HttpServletResponseWrapper, HttpServletResponse}
+import jakarta.servlet.http.{HttpServletResponseWrapper, HttpServletResponse}
 import org.slf4j.{LoggerFactory, Logger}
 
 class LoggingHandler(underlying: HttpService, log: Logger = LoggingHandler.defaultLog) extends HttpService {

--- a/socrata-http-server/src/main/scala/com/socrata/http/server/util/handlers/NewLoggingHandler.scala
+++ b/socrata-http-server/src/main/scala/com/socrata/http/server/util/handlers/NewLoggingHandler.scala
@@ -1,7 +1,7 @@
 package com.socrata.http.server.util.handlers
 
 import com.socrata.http.server.{HttpRequest, HttpService}
-import javax.servlet.http.HttpServletResponse
+import jakarta.servlet.http.HttpServletResponse
 import org.slf4j.{LoggerFactory, Logger, MDC}
 
 /**

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "3.16.2"
+ThisBuild / version := "3.17.0"


### PR DESCRIPTION
This version updates Jetty to 11.0.20 and switches javax out for jakarta. These changes allow this library to be used in projects using Java >= 9. 
The ability to set excludeUserAgents on the gzip handler has been deprecated by Jetty as its primary purpose was to deal with IE's continued existence. 