### PR TITLE
A mimetype suffix should not prevent matching against a non-suffixed mimetype.

### DIFF
--- a/socrata-http-client/src/main/scala/com/socrata/http/client/Response.scala
+++ b/socrata-http-client/src/main/scala/com/socrata/http/client/Response.scala
@@ -173,7 +173,7 @@ object Response {
   def subTypeSubSequence(pattern: MimeType, candidate: MimeType): Boolean = {
     val candidateSubType = candidate.getSubType.split("\\+").toSet
     val patternSubType = pattern.getSubType.split("\\+").toSet
-    candidateSubType.subsetOf(patternSubType)
+    patternSubType.subsetOf(candidateSubType)
   }
 
 

--- a/socrata-http-client/src/main/scala/com/socrata/http/client/Response.scala
+++ b/socrata-http-client/src/main/scala/com/socrata/http/client/Response.scala
@@ -170,8 +170,15 @@ object Response {
   private val appGeoJson = new MimeType("application/vnd.geo+json")
   private val textPlain = new MimeType("text/plain")
 
+  def subTypeSubSequence(pattern: MimeType, candidate: MimeType): Boolean = {
+    val candidateSubType = candidate.getSubType.split("\\+").toSet
+    val patternSubType = pattern.getSubType.split("\\+").toSet
+    candidateSubType.subsetOf(patternSubType)
+  }
+
+
   def matches(pattern: MimeType, candidate: MimeType): Boolean =
-    pattern.getPrimaryType == candidate.getPrimaryType && (pattern.getSubType == "*" || candidate.getSubType.startsWith(pattern.getSubType))
+    pattern.getPrimaryType == candidate.getPrimaryType && (pattern.getSubType == "*" || subTypeSubSequence(pattern, candidate))
 
   def acceptJson(mimeType: Option[MimeType]) = mimeType.fold(false)(matches(appJson, _))
   def acceptGeoJson(mimeType: Option[MimeType]) = mimeType.fold(false) { mt =>

--- a/socrata-http-client/src/main/scala/com/socrata/http/client/Response.scala
+++ b/socrata-http-client/src/main/scala/com/socrata/http/client/Response.scala
@@ -171,7 +171,7 @@ object Response {
   private val textPlain = new MimeType("text/plain")
 
   def matches(pattern: MimeType, candidate: MimeType): Boolean =
-    pattern.getPrimaryType == candidate.getPrimaryType && (pattern.getSubType == "*" || pattern.getSubType == candidate.getSubType)
+    pattern.getPrimaryType == candidate.getPrimaryType && (pattern.getSubType == "*" || candidate.getSubType.startsWith(pattern.getSubType))
 
   def acceptJson(mimeType: Option[MimeType]) = mimeType.fold(false)(matches(appJson, _))
   def acceptGeoJson(mimeType: Option[MimeType]) = mimeType.fold(false) { mt =>

--- a/socrata-http-client/src/main/scala/com/socrata/http/client/Response.scala
+++ b/socrata-http-client/src/main/scala/com/socrata/http/client/Response.scala
@@ -171,9 +171,15 @@ object Response {
   private val textPlain = new MimeType("text/plain")
 
   def subTypeSubSequence(pattern: MimeType, candidate: MimeType): Boolean = {
-    val candidateSubType = candidate.getSubType.split("\\+").toSet
-    val patternSubType = pattern.getSubType.split("\\+").toSet
-    patternSubType.subsetOf(candidateSubType)
+    val candidateSubType = candidate.getSubType.split("\\+").toList
+    val patternSubType = pattern.getSubType.split("\\+").toList
+
+    (patternSubType, candidateSubType) match {
+      case (pHead :: patternRest, cHead :: candidateRest) if pHead == cHead=>
+        patternRest.toSet.subsetOf(candidateRest.toSet)
+      case _ => false
+    }
+
   }
 
 

--- a/socrata-http-client/src/test/scala/com/socrata/http/client/ResponseSpec.scala
+++ b/socrata-http-client/src/test/scala/com/socrata/http/client/ResponseSpec.scala
@@ -17,10 +17,13 @@ class ResponseTest extends FunSuite with MustMatchers {
       ("foo/bar+baz", "foo/bar+baz", true),
       ("foo/bar+baz", "foo/bar", false),
       ("goo/bar", "foo/bar", false),
+      ("foo/baz+bar", "foo/bar+baz", false),
       ("application/json", "application/json+cjson", true),
       ("application/json+cjson", "application/json", false),
+      ("application/json+cjson", "application/json", false),
     ).foreach { case (pattern, candidate, matches) =>
-        println(pattern, candidate, matches)
+        val allowString = if (matches) "allows" else "denies"
+        println(s"$pattern $allowString $candidate")
         Response.matches(new MimeType(pattern), new MimeType(candidate)) must be (matches)
 
     }

--- a/socrata-http-client/src/test/scala/com/socrata/http/client/ResponseSpec.scala
+++ b/socrata-http-client/src/test/scala/com/socrata/http/client/ResponseSpec.scala
@@ -1,0 +1,29 @@
+package com.socrata.http.client
+
+import org.scalatest.{FunSuite, MustMatchers}
+import org.scalatest.prop.PropertyChecks
+import java.io.Reader
+import javax.activation.{MimeTypeParseException, MimeType}
+import com.rojoma.json.v3.ast.JValue
+import com.rojoma.json.v3.testsupport.ArbitraryJValue
+import com.rojoma.json.v3.io.{CompactJsonWriter, JValueEventIterator}
+import org.scalacheck.Arbitrary
+
+class ResponseTest extends FunSuite with MustMatchers {
+  test("Mimetype matching works as expected") {
+    List(
+      ("foo/bar", "foo/bar", true),
+      ("foo/bar", "foo/bar+baz", true),
+      ("foo/bar+baz", "foo/bar+baz", true),
+      ("foo/bar+baz", "foo/bar", false),
+      ("goo/bar", "foo/bar", false),
+      ("application/json", "application/json+cjson", true),
+      ("application/json+cjson", "application/json", false),
+    ).foreach { case (pattern, candidate, matches) =>
+        println(pattern, candidate, matches)
+        Response.matches(new MimeType(pattern), new MimeType(candidate)) must be (matches)
+
+    }
+
+  }
+}


### PR DESCRIPTION
`application/json+x-socrata-cjson` should be considered `application/json`

mime-type suffixes: https://en.wikipedia.org/wiki/Media_type#Suffix