### PR TITLE
Rework otel attributes from the latest spec

### DIFF
--- a/socrata-http-server-otel/src/main/scala/com/socrata/http/server/otel/OtelHandler.scala
+++ b/socrata-http-server-otel/src/main/scala/com/socrata/http/server/otel/OtelHandler.scala
@@ -3,6 +3,7 @@ package otel
 
 import scala.collection.JavaConverters._
 
+import jakarta.servlet.http.HttpServletResponse
 import io.opentelemetry.api.trace.{Span, SpanKind, Tracer}
 import io.opentelemetry.context.propagation.ContextPropagators
 import io.opentelemetry.api.incubator.trace.ExtendedSpanBuilder
@@ -11,7 +12,8 @@ class OtelHandler private (
   underlying: HttpService,
   tracer: Tracer,
   propagators: ContextPropagators,
-  attributes: (Span, HttpRequest) => Unit
+  preAttributes: (Span, HttpRequest) => Unit,
+  postAttributes: (Span, HttpServletResponse) => Unit
 ) extends HttpService {
   def apply(req: HttpRequest) = { resp =>
     tracer.spanBuilder(s"${req.method} ${req.requestPathStr}")
@@ -24,9 +26,41 @@ class OtelHandler private (
       )
       .setSpanKind(SpanKind.SERVER)
       .startAndRun { () =>
-        attributes(Span.current, req)
+        val span = Span.current
+
+        requiredPreAttributes(span, req)
+        preAttributes(span, req)
+
         underlying(req)(resp)
+
+        requiredPostAttributes(span, resp)
+        postAttributes(span, resp)
       }
+  }
+
+  // Standard attributes which can be derived from the request, from
+  // https://opentelemetry.io/docs/specs/semconv/http/http-spans/#http-server-span
+  // This _only_ sets "required" attributes.  If you want to set any more,
+  // provide your own function
+  private def requiredPreAttributes(span: Span, req: HttpRequest): Unit = {
+    span.setAttribute("http.request.method", req.method)
+    span.setAttribute("url.scheme", req.servletRequest.getScheme)
+    span.setAttribute("url.path", req.requestPathStr)
+    req.queryStr.foreach(span.setAttribute("url.query", _))
+  }
+
+  // Standard attributes which can be derived from the response, from
+  // https://opentelemetry.io/docs/specs/semconv/http/http-spans/#http-server-span
+  // This _only_ sets "required" attributes.  If you want to set any more,
+  // provide your own function
+  private def requiredPostAttributes(span: Span, resp: HttpServletResponse): Unit = {
+    val status = resp.getStatus
+    span.setAttribute("http.response.status_code", status)
+    if(status >= 400) {
+      // required if the result is an error; per the spec this can
+      // just be an HTTP status code.
+      span.setAttribute("error.type", status)
+    }
   }
 }
 
@@ -34,14 +68,10 @@ object OtelHandler {
   def apply(
     tracer: Tracer,
     propagators: ContextPropagators,
-    attributes: (Span, HttpRequest) => Unit = standardAttributes
+    preAttributes: (Span, HttpRequest) => Unit = noop,
+    postAttributes: (Span, HttpServletResponse) => Unit = noop
   )(handler: HttpService) =
-    new OtelHandler(handler, tracer, propagators, attributes)
+    new OtelHandler(handler, tracer, propagators, preAttributes, postAttributes)
 
-  def standardAttributes(span: Span, req: HttpRequest): Unit = {
-    span.setAttribute("component", "http")
-    span.setAttribute("http.method", req.method)
-    span.setAttribute("http.scheme", "http")
-    span.setAttribute("http.target", req.requestPathStr)
-  }
+  private def noop(span: Span, thing: Any): Unit = {}
 }


### PR DESCRIPTION
What I was working from before (an official otel sdk example, heh) uses deprecated attributes.

This also makes it so required attributes are automatically set and only provides a way to augment them, rather than allowing them to be completely replaced.