### PR TITLE
More otel improvements

### DIFF
--- a/socrata-http-server-otel/src/main/scala/com/socrata/http/server/otel/OtelHandler.scala
+++ b/socrata-http-server-otel/src/main/scala/com/socrata/http/server/otel/OtelHandler.scala
@@ -4,6 +4,7 @@ package otel
 import scala.collection.JavaConverters._
 
 import jakarta.servlet.http.HttpServletResponse
+import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.trace.{Span, SpanKind, Tracer}
 import io.opentelemetry.context.propagation.ContextPropagators
 import io.opentelemetry.api.incubator.trace.ExtendedSpanBuilder
@@ -13,29 +14,36 @@ class OtelHandler private (
   tracer: Tracer,
   propagators: ContextPropagators,
   preAttributes: (Span, HttpRequest) => Unit,
-  postAttributes: (Span, HttpServletResponse) => Unit
+  postAttributes: (Span, HttpServletResponse) => Unit,
+  record: (HttpRequest) => Boolean
 ) extends HttpService {
+  private val keys = OtelHandler.Keys
+
   def apply(req: HttpRequest) = { resp =>
-    tracer.spanBuilder(s"${req.method} ${req.requestPathStr}")
-      .asInstanceOf[ExtendedSpanBuilder]
-      .setParentFrom(
-        propagators,
-        req.servletRequest.getHeaderNames.asScala.map { h =>
-          h -> req.header(h).get
-        }.toMap.asJava
-      )
-      .setSpanKind(SpanKind.SERVER)
-      .startAndRun { () =>
-        val span = Span.current
+    if(record(req)) {
+      tracer.spanBuilder(s"${req.method} ${req.requestPathStr}")
+        .asInstanceOf[ExtendedSpanBuilder]
+        .setParentFrom(
+          propagators,
+          req.servletRequest.getHeaderNames.asScala.map { h =>
+            h -> req.header(h).get
+          }.toMap.asJava
+        )
+        .setSpanKind(SpanKind.SERVER)
+        .startAndRun { () =>
+          val span = Span.current
 
-        requiredPreAttributes(span, req)
-        preAttributes(span, req)
+          requiredPreAttributes(span, req)
+          preAttributes(span, req)
 
-        underlying(req)(resp)
+          underlying(req)(resp)
 
-        requiredPostAttributes(span, resp)
-        postAttributes(span, resp)
-      }
+          requiredPostAttributes(span, resp)
+          postAttributes(span, resp)
+        }
+    } else {
+      underlying(req)(resp)
+    }
   }
 
   // Standard attributes which can be derived from the request, from
@@ -43,10 +51,11 @@ class OtelHandler private (
   // This _only_ sets "required" attributes.  If you want to set any more,
   // provide your own function
   private def requiredPreAttributes(span: Span, req: HttpRequest): Unit = {
-    span.setAttribute("http.request.method", req.method)
-    span.setAttribute("url.scheme", req.servletRequest.getScheme)
-    span.setAttribute("url.path", req.requestPathStr)
-    req.queryStr.foreach(span.setAttribute("url.query", _))
+    span.setAttribute(keys.httpRequestMethod, req.method)
+    span.setAttribute(keys.urlFull, req.servletRequest.getRequestURL.toString)
+    span.setAttribute(keys.urlScheme, req.servletRequest.getScheme)
+    span.setAttribute(keys.urlQuery, req.requestPathStr)
+    req.queryStr.foreach(span.setAttribute(keys.urlQuery, _))
   }
 
   // Standard attributes which can be derived from the response, from
@@ -55,23 +64,37 @@ class OtelHandler private (
   // provide your own function
   private def requiredPostAttributes(span: Span, resp: HttpServletResponse): Unit = {
     val status = resp.getStatus
-    span.setAttribute("http.response.status_code", status)
+    span.setAttribute(keys.httpResponseStatusCode, status)
     if(status >= 400) {
       // required if the result is an error; per the spec this can
       // just be an HTTP status code.
-      span.setAttribute("error.type", status)
+      span.setAttribute(keys.errorType, status)
     }
   }
 }
 
 object OtelHandler {
+  private object Keys {
+    val httpRequestMethod = AttributeKey.stringKey("http.request.method")
+    val urlFull = AttributeKey.stringKey("url.full")
+    val urlScheme = AttributeKey.stringKey("url.scheme")
+    val urlPath = AttributeKey.stringKey("url.path")
+    val urlQuery = AttributeKey.stringKey("url.query")
+
+    val httpResponseStatusCode = AttributeKey.longKey("http.response.status_code")
+    val errorType = AttributeKey.longKey("error.type")
+  }
+
   def apply(
     tracer: Tracer,
     propagators: ContextPropagators,
     preAttributes: (Span, HttpRequest) => Unit = noop,
-    postAttributes: (Span, HttpServletResponse) => Unit = noop
+    postAttributes: (Span, HttpServletResponse) => Unit = noop,
+    record: (HttpRequest) => Boolean = yes
   )(handler: HttpService) =
-    new OtelHandler(handler, tracer, propagators, preAttributes, postAttributes)
+    new OtelHandler(handler, tracer, propagators, preAttributes, postAttributes, record)
 
   private def noop(span: Span, thing: Any): Unit = {}
+
+  private def yes(req: HttpRequest) = true
 }


### PR DESCRIPTION
* put url.full in the set of things we record, because xray wants it
* crate a static set of AttributeKeys to use (otel-sdk docs say this is more efficient)
* add a way to exclude requests from tracing (basically to ignore /version)